### PR TITLE
New feature about permission and owner of log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@ __pycache__
 env
 venv
 env_py27
-*.lock
 *.log*
+.__*.lock

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__
 env
 venv
 env_py27
+*.lock
+*.log*

--- a/README.md
+++ b/README.md
@@ -121,3 +121,10 @@ https://github.com/Preston-Landers
 https://github.com/und3rc
 
 https://github.com/wcooley
+
+https://github.com/greenfrog82
+
+## TODO ## 
+
+We should probably preserve existing owners and permissions on the
+log file when we roll it over.

--- a/src/concurrent_log_handler/__init__.py
+++ b/src/concurrent_log_handler/__init__.py
@@ -52,6 +52,7 @@ This module supports Python 2.6 and later.
 
 """
 
+import pwd, grp, stat
 import os
 import sys
 import pwd, grp
@@ -124,6 +125,8 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
         :param debug: add extra debug statements to this class (for development)
         :param delay: see note below
         :param use_gzip: automatically gzip rotated logs if available.
+        :param owner: owner of log files.
+        :param chmod: permission of log files.
 
         By default, the file grows indefinitely. You can specify particular
         values of maxBytes and backupCount to allow the file to rollover at
@@ -165,6 +168,7 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
         self.stream = None
         self.owner = owner
         self.chmod = chmod
+        self.use_gzip = True if gzip and use_gzip else False
         # Absolute file name handling done by FileHandler since Python 2.5  
         super(ConcurrentRotatingFileHandler, self).__init__(
             filename, mode, encoding=encoding, delay=delay)
@@ -371,6 +375,7 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
             try:
                 # Do a rename test to determine if we can successfully rename the log file
                 os.rename(self.baseFilename, tmpname)
+
                 if self.use_gzip:
                     self.do_gzip(tmpname)
             except (IOError, OSError):
@@ -481,7 +486,6 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
 
         if self.chmod:
             os.chmod(filename, self.chmod)
-
 
 # Publish this class to the "logging.handlers" module so that it can be use
 # from a logging config file via logging.config.fileConfig().

--- a/src/concurrent_log_handler/__init__.py
+++ b/src/concurrent_log_handler/__init__.py
@@ -52,7 +52,6 @@ This module supports Python 2.6 and later.
 
 """
 
-import pwd, grp, stat
 import os
 import sys
 import pwd, grp

--- a/src/example.py
+++ b/src/example.py
@@ -1,0 +1,37 @@
+import logging
+import logging.config
+import concurrent_log_handler
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'default': {
+            'format': '%(asctime)s %(levelname)s %(name)s %(message)s'
+        },
+    },
+    'handlers': {
+        'file': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.ConcurrentRotatingFileHandler',
+            'formatter': 'default',
+            'filename': 'test.log',
+            'owner': ['greenfrog', 'admin'],
+            'chmod': 0660,
+            'maxBytes': 30,
+            'backupCount': 10,
+            'use_gzip': True,
+            'delay': True
+        }
+    },
+    'root': {
+        'handlers': ['file'],
+        'level': 'DEBUG',
+    },
+}
+
+logging.config.dictConfig(LOGGING)
+logger = logging.getLogger(__name__)
+
+for idx in range(0, 10):
+    logger.debug('%d > A debug message' % idx)

--- a/src/example.py
+++ b/src/example.py
@@ -17,7 +17,7 @@ LOGGING = {
             'formatter': 'default',
             'filename': 'test.log',
             'owner': ['greenfrog', 'admin'],
-            'chmod': 0660,
+            'chmod': 0o0660,
             'maxBytes': 30,
             'backupCount': 10,
             'use_gzip': True,


### PR DESCRIPTION
Hi all ~
I'm using concurrent-log-handler very usefully.  
But I had some problem about permission and owner of log file. Our company put a primium on security. So we set limited permission and owner on log files.

Unfortunately, the concurrent-log-handler has not feature to set permission and owner on log file. So I made default log file with touch command and I set permission and owner it with chmod and chown command.
Finally, I guess that this problem about permission and owner of log file is done.

But the problem occrued when the log file was rotated. 
A permission of the new log file after rotating was different with original log file which was made by me. A permission of original log file was 660 but a permission of new log file was 644. 

In the end, I decied adding new feature to set permission and owner on log file.
This pull request about it.
Please check this feature and codes. 

Thank you!!

P.S 
I'm developing and operating my service only on linux. So this feature only tested on linux.