### PR TITLE
fix issue #19: don't open logs as binary files

### DIFF
--- a/src/concurrent_log_handler/__init__.py
+++ b/src/concurrent_log_handler/__init__.py
@@ -250,11 +250,7 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
             mode = self.mode
 
         with self._alter_umask():
-            if self.encoding is None:
-                stream = open(self.baseFilename, mode)
-            else:
-                stream = codecs.open(self.baseFilename, mode, self.encoding)
-
+            stream = open(self.baseFilename, mode, encoding=self.encoding)
         self._do_chown_and_chmod(self.baseFilename)
 
         return stream


### PR DESCRIPTION
don't open logs as binary files when an encoding is specified, which caused Unix EOLs on Windows