### PR TITLE
Optimization for asyncio queue? only make a single AsyncQueueListener

### DIFF
--- a/src/concurrent_log_handler/queue.py
+++ b/src/concurrent_log_handler/queue.py
@@ -70,6 +70,11 @@ def setup_logging_queues():
 
     previous_queue_listeners = []
 
+    log_queue = queue.Queue(-1)  # No limit on size
+    queue_handler = QueueHandler(log_queue)
+    queue_listener = AsyncQueueListener(
+        log_queue, respect_handler_level=True)
+
     # Q: What about loggers created after this is called?
     # A: if they don't attach their own handlers they should be fine
     for logger_name in get_all_logger_names(include_root=True):
@@ -91,12 +96,6 @@ def setup_logging_queues():
                 previous_queue_listeners.append(GLOBAL_LOGGER_HANDLERS[logger_name][1])
             else:
                 ori_handlers.extend(logger.handlers)
-
-            log_queue = queue.Queue(-1)  # No limit on size
-
-            queue_handler = QueueHandler(log_queue)
-            queue_listener = AsyncQueueListener(
-                log_queue, respect_handler_level=True)
 
             queuify_logger(logger, queue_handler, queue_listener)
             # print("Replaced logger %s with queue listener: %s" % (


### PR DESCRIPTION
Hey @ZhuYuJin  - you recently contributed in this area of the asyncio logging queue. I was reviewing this code a little more and it seemed to me that it might be unnecessary to create separate instances of these objects for each logger object:

```
AsyncQueueListener ->
   QueueHandler -> 
       queue.Queue  
```

As far as I can tell there's no harm in having a single `AsyncQueueListener` handle all the loggers within that process. Or am I maybe missing something? I wonder if you could perhaps try out this branch and let me know what you think.

It wouldn't be a major speed boost, but may some minor memory savings if there are a lot of loggers configured.