### PR TITLE
Correct the class of my_concurrent_log

### DIFF
--- a/src/example.py
+++ b/src/example.py
@@ -75,7 +75,7 @@ def my_logging_setup(log_name='example.log', use_async=False):
         'handlers': {
             'my_concurrent_log': {
                 'level': 'DEBUG',
-                'class': 'logging.handlers.ConcurrentRotatingFileHandler',
+                'class': 'concurrent_log_handler.ConcurrentRotatingFileHandler',
 
                 # Example of a custom format for this log.
                 'formatter': 'example2',


### PR DESCRIPTION
In src/example.py, the package name of the ConcurrentRotatingFileHander should be concurrent_log_handler, was logging.handlers.