### PR TITLE
Implement ConcurrentTimedRotatingFileHandler

### DIFF
--- a/src/concurrent_log_handler/__init__.py
+++ b/src/concurrent_log_handler/__init__.py
@@ -63,7 +63,7 @@ import time
 import traceback
 import warnings
 from contextlib import contextmanager
-from logging.handlers import BaseRotatingHandler
+from logging.handlers import BaseRotatingHandler, TimedRotatingFileHandler
 
 from portalocker import LOCK_EX, lock, unlock
 from concurrent_log_handler.__version__ import __author__, __version__
@@ -103,7 +103,9 @@ if sys.version_info[0] == 2:
     PY2 = True
 
 
-class ConcurrentRotatingFileHandler(BaseRotatingHandler):
+
+
+class ConcurrentFileHandlerMixin:
     """
     Handler for logging to a set of files, which switches from one file to the
     next when the current file reaches a certain size. Multiple processes can
@@ -206,7 +208,7 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
         # Construct the handler with the given arguments in "delayed" mode
         # because we will handle opening the file as needed. File name
         # handling is done by FileHandler since Python 2.5.
-        super(ConcurrentRotatingFileHandler, self).__init__(
+        super(ConcurrentFileHandlerMixin, self).__init__(
             filename, mode, encoding=encoding, delay=True)
 
         self.terminator = terminator or "\n"
@@ -436,7 +438,7 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
         try:
             self._close()
         finally:
-            super(ConcurrentRotatingFileHandler, self).close()
+            super(ConcurrentFileHandlerMixin, self).close()
 
     def doRollover(self):
         """
@@ -531,17 +533,6 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
         del record  # avoid pychecker warnings
         return self._shouldRollover()
 
-    def _shouldRollover(self):
-        if self.maxBytes > 0:  # are we rolling over?
-            self.stream = self.do_open()
-            try:
-                self.stream.seek(0, 2)  # due to non-posix-compliant Windows feature
-                if self.stream.tell() >= self.maxBytes:
-                    return True
-            finally:
-                self._close()
-        return False
-
     def do_gzip(self, input_filename):
         if not gzip:
             self._console_log("#no gzip available", stack=False)
@@ -568,8 +559,26 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
             os.chmod(filename, self.chmod)
 
 
+class ConcurrentRotatingFileHandler(BaseRotatingHandler, ConcurrentFileHandlerMixin):
+    def _shouldRollover(self):
+        if self.maxBytes > 0:  # are we rolling over?
+            self.stream = self.do_open()
+            try:
+                self.stream.seek(0, 2)  # due to non-posix-compliant Windows feature
+                if self.stream.tell() >= self.maxBytes:
+                    return True
+            finally:
+                self._close()
+        return False
+
+
+class ConcurrentTimedRotatingFileHandler(TimedRotatingFileHandler, ConcurrentFileHandlerMixin):
+    pass
+
+
 # Publish this class to the "logging.handlers" module so that it can be use
 # from a logging config file via logging.config.fileConfig().
 import logging.handlers
 
 logging.handlers.ConcurrentRotatingFileHandler = ConcurrentRotatingFileHandler
+logging.handlers.ConcurrentTimedRotatingFileHandler = ConcurrentTimedRotatingFileHandler


### PR DESCRIPTION
Move the current implementation of RotatingFileHandler to a mixin (aside
the shouldRollover method).

Use the mixin to patch the new implementations into the two subclasses
(ConcurrentTimedRotatingFileHandler and ConcurrentRotatingFileHandler).

Move the specific shouldRollover logic to the
ConcurrentRotatingFileHandler implementation.

fixes: #23 