### PR TITLE
fix doRollover(missing 1 file to rename)

### DIFF
--- a/src/concurrent_log_handler/__init__.py
+++ b/src/concurrent_log_handler/__init__.py
@@ -497,7 +497,7 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
         # code complexity isn't warranted.
 
         do_renames = []
-        for i in range(1, self.backupCount - 1):
+        for i in range(1, self.backupCount):
             sfn = "%s.%d" % (self.baseFilename, i)
             dfn = "%s.%d" % (self.baseFilename, i + 1)
             if os.path.exists(sfn + gzip_ext):


### PR DESCRIPTION
Hi, I found the backup file with greatest backup number won't be replaced, this PR should fix this issue.