### PR TITLE
Fixes Issue #66: ConcurrentTimedRotatingFileHandler rotating gzip fil…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "justMyCode": true
+        },
+        {
+            "name": "CLH PyTests",
+            "type": "python",
+            "request": "launch",
+            "module": "pytest",
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/tests",
+            "args": [],
+            "justMyCode": false
+        },        
+        {
+            "name": "Concurrent Log Handler basic example",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/tests/other/test.py",
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/tests/other",
+            "justMyCode": true
+        },
+        {
+            "name": "CLH old stress test",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/tests/other/stresstest.py",
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/tests/other",
+            "args": ["--log-calls", "2000"],
+            "justMyCode": true
+        },
+    ]
+}

--- a/src/concurrent_log_handler/__init__.py
+++ b/src/concurrent_log_handler/__init__.py
@@ -836,8 +836,10 @@ class ConcurrentTimedRotatingFileHandler(TimedRotatingFileHandler):
             self.clh.do_gzip(dfn)
 
         if self.backupCount > 0:
-            for s in self.getFilesToDelete():
-                os.remove(s + gzip_ext)
+            # File will already have gzip extension here if applicable
+            # Thanks to @moynihan
+            for file in self.getFilesToDelete():
+                os.remove(file)
         # if not self.delay:
         #     self.stream = self._open()
         newRolloverAt = self.computeRollover(currentTime)

--- a/tests/other/stresstest.py
+++ b/tests/other/stresstest.py
@@ -28,10 +28,11 @@ from subprocess import Popen
 from time import sleep
 
 # local lib; for testing
-from concurrent_log_handler import PY2, ConcurrentRotatingFileHandler, randbits
+from concurrent_log_handler import ConcurrentRotatingFileHandler, randbits
 
-__version__ = "$Id$"
 __author__ = "Lowell Alleman"
+
+PY2 = False  # No longer supporting Python 2.7
 
 # ruff: noqa: F821, E501
 
@@ -252,7 +253,7 @@ def rand_string(str_len):
 
 parser = OptionParser(
     usage="usage:  %prog",
-    version=__version__,
+    # version=__version__,
     description="Stress test the concurrent_log_handler module.",
 )
 parser.add_option(

--- a/tests/test_stresstest.py
+++ b/tests/test_stresstest.py
@@ -3,6 +3,11 @@
 
 """
 Pytest based unit test cases to drive stresstest.py.
+
+See comments about backupCount in stresstest.py. In short,
+if backupCount is set here less than 10, we assume that
+some logs are deleted before the end of the test and therefore
+don't test specifically for missing lines/items.
 """
 
 import pytest
@@ -10,6 +15,12 @@ from stresstest import TestOptions, run_stress_test
 
 TEST_CASES = {
     "default test options": TestOptions(),
+    "backupCount=3": TestOptions(
+        log_opts=TestOptions.default_log_opts({"backupCount": 3}),
+    ),
+    "backupCount=3, use_gzip=True": TestOptions(
+        log_opts=TestOptions.default_log_opts({"backupCount": 3, "use_gzip": True}),
+    ),
     "num_processes=2, log_calls=6_000": TestOptions(
         num_processes=2, log_calls=6_000, min_rollovers=80
     ),
@@ -65,6 +76,32 @@ TEST_CASES = {
             }
         ),
     ),
+    "backupCount=3, use_gzip=True, use_timed=True, interval=3, log_calls=3_000, num_processes=4": TestOptions(
+        use_timed=True,
+        num_processes=4,
+        log_calls=3_000,
+        min_rollovers=4,
+        log_opts=TestOptions.default_timed_log_opts(
+            {
+                "backupCount": 3,
+                "interval": 3,
+                "use_gzip": True,
+            }
+        ),
+    ),
+    "backupCount=4, use_timed=True, interval=4, log_calls=3_000, num_processes=5": TestOptions(
+        use_timed=True,
+        num_processes=5,
+        log_calls=3_000,
+        min_rollovers=3,
+        log_opts=TestOptions.default_timed_log_opts(
+            {
+                "backupCount": 4,
+                "interval": 4,
+                "use_gzip": False,
+            }
+        ),
+    ),
     "use_timed=True, num_processes=15, interval=1, log_calls=5_000, use_gzip=True": TestOptions(
         use_timed=True,
         log_calls=5_000,
@@ -102,9 +139,6 @@ TEST_CASES = {
             }
         ),
     ),
-    # TODO: it would be good to have some test cases that verify that backupCount is not exceeded.
-    # Testing time intervals other than seconds is difficult because the tests would
-    # take hours unless we find a way to mock things.
 }
 
 


### PR DESCRIPTION
…es fails

The gzip extension is already present in the return value of `getFilesToDelete` in Python's `TimedRotatingFileHandler` and doesn't needed to be added. This was causing it to fail to rollover properly in Timed mode.