### PR TITLE
Initial support for typing

### DIFF
--- a/.github/workflows/clh_tests.yaml
+++ b/.github/workflows/clh_tests.yaml
@@ -24,7 +24,7 @@ jobs:
           pip3 install --upgrade hatch
       - name: Run linting
         run: |
-          hatch run lint:style
+          hatch run lint:all
 
   test:
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,9 +92,14 @@ dependencies = [
   "black>=23.9.1",
   "mypy>=1.6.0",
   "ruff>=0.1.0",
+  "portalocker",
 ]
 
 [tool.hatch.envs.lint.scripts]
+typing = [
+  "mypy --version",
+  "mypy --install-types --non-interactive {args:src/concurrent_log_handler}"
+  ]
 style = [
   "ruff {args:.}",
   "black --check --diff {args:.}",
@@ -103,6 +108,10 @@ fmt = [
   "black {args:.}",
   "ruff {args:.}",
   "style",
+]
+all = [
+  "style",
+  "typing",
 ]
 
 [tool.ruff]
@@ -186,3 +195,21 @@ testpaths =["tests"]
 omit = [
   "tests/stresstest.py"
 ]
+
+[tool.mypy]
+python_version = "3.8"
+platform = "linux"
+disallow_any_unimported = true
+disallow_any_explicit = true
+disallow_untyped_defs = true
+disallow_untyped_calls = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+strict_optional = true
+
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_configs = true


### PR DESCRIPTION
It's probably a little rough, but this add some initial support for typing of the library and declaring it as such via `py.typed`.

It uses `mypy`, again as I'm familiar and I know it has good support for `pyproject.toml`.  I saw some comments regarding/for PyTypeChecker, which I think should still be fine.  I tried to leave those as is where I found them.

As much as possible, I didn't change code and didn't ignore types, except when it was a real rabbit hole.  Tests still run clean, so I think should be fine.